### PR TITLE
Added logic to handle non-exlusive subscriptions

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -57,7 +57,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 
 public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcessor {
 
-    static final AllowableValue EXCLUSIVE = new AllowableValue("Exclusive", "Exclusive", "There can be only 1 consumer on the same topic with the same subscription name");
+    protected static final AllowableValue EXCLUSIVE = new AllowableValue("Exclusive", "Exclusive", "There can be only 1 consumer on the same topic with the same subscription name");
     static final AllowableValue SHARED = new AllowableValue("Shared", "Shared", "Multiple consumer will be able to use the same subscription name and the messages");
     static final AllowableValue FAILOVER = new AllowableValue("Failover", "Failover", "Multiple consumer will be able to use the same subscription name but only 1 consumer "
             + "will receive the messages. If that consumer disconnects, one of the other connected consumers will start receiving messages.");

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -84,6 +84,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run(10, true);
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
@@ -109,6 +110,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         runner.setProperty(ConsumePulsar.TOPICS, topic);
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, sub);
         runner.setProperty(ConsumePulsar.CONSUMER_BATCH_SIZE, batchSize + "");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.setProperty(ConsumePulsar.MESSAGE_DEMARCATOR, "\n");
         runner.run(1, true);
 
@@ -146,6 +148,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         runner.setProperty(ConsumePulsar.TOPICS, topic);
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, sub);
         runner.setProperty(ConsumePulsar.CONSUMER_BATCH_SIZE, 1 + "");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run(iterations, true);
 
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
@@ -41,6 +41,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
@@ -57,6 +58,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
@@ -75,6 +77,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
@@ -111,6 +114,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
         runner.setProperty(ConsumePulsar.CONSUMER_BATCH_SIZE, 1 + "");
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
         runner.run(1, true);
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 


### PR DESCRIPTION
Added logic first change the Consumers subscription type, and use cumulative acknowledgment for EXCLUSIVE subscriptions and single-message acknowledging for all others.

If we attempt to use cumulative acknowledgment on an non-exclusive subscription, and error is thrown and the messages do not get acked.