### PR TITLE
Update .gitignore (copied from apache/nifi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
+target
 .project
-.settings/
-*/.classpath
-*/.gitignore
-*/target/
-/target/
+.settings
+.classpath
+nbactions.xml
+nb-configuration.xml
 .DS_Store
+.metadata
+.recommenders
+
+# Intellij
+.idea/
+*.iml
+*.iws
+*~
+
+.vscode/


### PR DESCRIPTION
We would like to ignore IntelliJ files, so I copied `.gitignore` from nifi ( https://github.com/apache/nifi/blob/master/.gitignore ).