### PR TITLE
Add 'addValidator' to TENANT_PRIVATE_KEY_ID because we cannot enable the controller service without 'addValidator'

### DIFF
--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
@@ -72,6 +72,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .name("Tenants Private Key Id")
             .description("The id of tenant's private key.")
             .defaultValue("0")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .required(false)
             .sensitive(false)
             .build();


### PR DESCRIPTION
We need to add 'addValidator' to all properties, otherwise the following error occurs when we try to enable the controller service.

<img width="606" alt="スクリーンショット 2019-07-17 16 42 57" src="https://user-images.githubusercontent.com/1787125/61440693-0fa62c00-a97f-11e9-9db2-01d03fb0f98a.png">
