### PR TITLE
Add '.required(true)' to all properties that should be required in PulsarClientAthenzAuthenticationService

### DIFF
--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
@@ -41,6 +41,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .description("The domain name for this tenant")
             .defaultValue(null)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(true)
             .sensitive(false)
             .build();
     
@@ -49,6 +50,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .description("The service name for this tenant")
             .defaultValue(null)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(true)
             .sensitive(false)
             .build();
 	
@@ -57,6 +59,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .description("The provider domain name")
             .defaultValue(null)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(true)
             .sensitive(false)
             .build();
     
@@ -65,6 +68,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .description("The fully-qualified filename of the tenant's private key.")
             .defaultValue(null)
             .addValidator(createFileExistsAndReadableValidator())
+            .required(true)
             .sensitive(false)
             .build();
     


### PR DESCRIPTION
In the current implementation, some properties of PulsarClientAthenzAuthenticationService are not given either `.required(true)` or `.required(false)`. This PR will add `.required(true)` to properties that is thought to be required.