### PR TITLE
Define pulsar-client-auth-athenz at nifi-pulsar-client-service-api to avoid ClassNotFoundException

### DIFF
--- a/nifi-pulsar-client-service-api/pom.xml
+++ b/nifi-pulsar-client-service-api/pom.xml
@@ -37,6 +37,11 @@
             <version>${pulsar.version}</version>
 		</dependency>
         <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client-auth-athenz</artifactId>
+            <version>${pulsar.version}</version>
+        </dependency>
+        <dependency>
         	<groupId>org.apache.commons</groupId>
         	<artifactId>commons-collections4</artifactId>
         	<version>4.2</version>

--- a/nifi-pulsar-client-service/pom.xml
+++ b/nifi-pulsar-client-service/pom.xml
@@ -27,11 +27,6 @@
 
     <dependencies>
         <dependency>
-           <groupId>org.apache.pulsar</groupId>
-           <artifactId>pulsar-client-auth-athenz</artifactId>
-           <version>${pulsar.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-pulsar-client-service-api</artifactId>
             <version>1.9.0</version>


### PR DESCRIPTION
We need to add the dependency of pulsar-client-auth-athenz in `nifi-pulsar-client-service-api/pom.xml` instead of `nifi-pulsar-client-service/pom.xml`, otherwise when we try to enable the controller service the following ClassNotFoundException is raised.

```
2019-07-17 16:48:51,416 ERROR [Timer-Driven Process Thread-7] o.a.n.p.a.PulsarClientAthenzAuthenticationService PulsarClientAthenzAuthenticationService[id=fe4e5b8b-016b-1000-31f4-df5f826a717e] Unable to authenticate: org.apache.pulsar.client.api.PulsarClientException$UnsupportedAuthenticationException: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
org.apache.pulsar.client.api.PulsarClientException$UnsupportedAuthenticationException: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.apache.pulsar.client.api.AuthenticationFactory.create(AuthenticationFactory.java:101)
	at org.apache.nifi.pulsar.auth.PulsarClientAthenzAuthenticationService.getAuthentication(PulsarClientAthenzAuthenticationService.java:115)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.nifi.controller.service.StandardControllerServiceInvocationHandler.invoke(StandardControllerServiceInvocationHandler.java:87)
	at com.sun.proxy.$Proxy88.getAuthentication(Unknown Source)
	at org.apache.nifi.pulsar.StandardPulsarClientService.getClientBuilder(StandardPulsarClientService.java:262)
	at org.apache.nifi.pulsar.StandardPulsarClientService.onEnabled(StandardPulsarClientService.java:202)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.nifi.util.ReflectionUtils.invokeMethodsWithAnnotations(ReflectionUtils.java:142)
	at org.apache.nifi.util.ReflectionUtils.invokeMethodsWithAnnotations(ReflectionUtils.java:130)
	at org.apache.nifi.util.ReflectionUtils.invokeMethodsWithAnnotations(ReflectionUtils.java:75)
	at org.apache.nifi.util.ReflectionUtils.invokeMethodsWithAnnotation(ReflectionUtils.java:52)
	at org.apache.nifi.controller.service.StandardControllerServiceNode$2.run(StandardControllerServiceNode.java:436)
	at org.apache.nifi.engine.FlowEngine$2.run(FlowEngine.java:110)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.apache.pulsar.client.internal.ReflectionUtils.catchExceptions(ReflectionUtils.java:36)
	at org.apache.pulsar.client.internal.DefaultImplementation.createAuthentication(DefaultImplementation.java:109)
	at org.apache.pulsar.client.api.AuthenticationFactory.create(AuthenticationFactory.java:99)
	... 26 common frames omitted
Caused by: java.lang.reflect.InvocationTargetException: null
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.pulsar.client.internal.DefaultImplementation.lambda$createAuthentication$8(DefaultImplementation.java:112)
	at org.apache.pulsar.client.internal.ReflectionUtils.catchExceptions(ReflectionUtils.java:34)
	... 28 common frames omitted
Caused by: org.apache.pulsar.client.api.PulsarClientException$UnsupportedAuthenticationException: java.lang.ClassNotFoundException: org.apache.pulsar.client.impl.auth.AuthenticationAthenz
	at org.apache.pulsar.client.impl.AuthenticationUtil.create(AuthenticationUtil.java:114)
	... 34 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.client.impl.auth.AuthenticationAthenz
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.apache.pulsar.client.impl.AuthenticationUtil.create(AuthenticationUtil.java:106)
	... 34 common frames omitted
```