### PR TITLE
Add several properties to PulsarClientAthenzAuthenticationService to support all Athenz auth params

### DIFF
--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -35,7 +36,7 @@ import org.apache.pulsar.client.impl.auth.AuthenticationAthenz;
  *
  */
 public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClientAuntenticationService {
-	
+
     public static final PropertyDescriptor TENANT_DOMAIN = new PropertyDescriptor.Builder()
             .name("The tenant domain name")
             .description("The domain name for this tenant")
@@ -43,7 +44,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .sensitive(false)
             .build();
-    
+
     public static final PropertyDescriptor TENANT_SERVICE = new PropertyDescriptor.Builder()
             .name("The tenant service name")
             .description("The service name for this tenant")
@@ -51,7 +52,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .sensitive(false)
             .build();
-	
+
     public static final PropertyDescriptor PROVIDER_DOMAIN = new PropertyDescriptor.Builder()
             .name("The provider domain")
             .description("The provider domain name")
@@ -59,7 +60,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .sensitive(false)
             .build();
-    
+
     public static final PropertyDescriptor TENANT_PRIVATE_KEY_FILE = new PropertyDescriptor.Builder()
             .name("Tenants Private Key Filename")
             .description("The fully-qualified filename of the tenant's private key.")
@@ -67,7 +68,7 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .addValidator(createFileExistsAndReadableValidator())
             .sensitive(false)
             .build();
-    
+
     public static final PropertyDescriptor TENANT_PRIVATE_KEY_ID = new PropertyDescriptor.Builder()
             .name("Tenants Private Key Id")
             .description("The id of tenant's private key.")
@@ -75,9 +76,50 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
             .required(false)
             .sensitive(false)
             .build();
-    
+
+    public static final PropertyDescriptor AUTO_PREFETCH_ENABLED = new PropertyDescriptor.Builder()
+            .name("Auto Prefetch Enabled")
+            .description("Specifies whether or not ZTS auto prefetching is enabled.")
+            .defaultValue("false")
+            .allowableValues("true", "false")
+            .required(false)
+            .sensitive(false)
+            .build();
+
+    public static final PropertyDescriptor ATHENZ_CONF_PATH = new PropertyDescriptor.Builder()
+            .name("Pulsar Athenz Conf Path")
+            .description("The fully-qualified filename of the Pulsar Athenz configuration file.")
+            .addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+            .required(false)
+            .sensitive(false)
+            .build();
+
+    public static final PropertyDescriptor PRINCIPAL_HEADER = new PropertyDescriptor.Builder()
+            .name("Principal Header")
+            .description("Header name of Principal Token.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(false)
+            .sensitive(false)
+            .build();
+
+    public static final PropertyDescriptor ROLE_HEADER = new PropertyDescriptor.Builder()
+            .name("Role Header")
+            .description("Header name of Role Token.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(false)
+            .sensitive(false)
+            .build();
+
+    public static final PropertyDescriptor ZTS_URL = new PropertyDescriptor.Builder()
+            .name("ZTS URL")
+            .description("The ZTS Server URL.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(false)
+            .sensitive(false)
+            .build();
+
     private static final List<PropertyDescriptor> properties;
-    
+
     static {
         List<PropertyDescriptor> props = new ArrayList<>();
         props.add(TRUST_CERTIFICATE);
@@ -86,32 +128,46 @@ public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClien
         props.add(PROVIDER_DOMAIN);
         props.add(TENANT_PRIVATE_KEY_FILE);
         props.add(TENANT_PRIVATE_KEY_ID);
+        props.add(AUTO_PREFETCH_ENABLED);
+        props.add(ATHENZ_CONF_PATH);
+        props.add(PRINCIPAL_HEADER);
+        props.add(ROLE_HEADER);
+        props.add(ZTS_URL);
         properties = Collections.unmodifiableList(props);
     }
-    
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return properties;
     }
 
-	@Override
-	public Authentication getAuthentication() {
-		Map<String, String> authParams = new HashMap<>();
-		authParams.put("tenantDomain", configContext.getProperty(TENANT_DOMAIN).getValue()); 
-		authParams.put("tenantService", configContext.getProperty(TENANT_SERVICE).getValue()); 
-		authParams.put("providerDomain", configContext.getProperty(PROVIDER_DOMAIN).getValue()); 
-		authParams.put("privateKey", configContext.getProperty(TENANT_PRIVATE_KEY_FILE).getValue()); 
-		
-		if (configContext.getProperty(TENANT_PRIVATE_KEY_ID).isSet()) {
-		   authParams.put("keyId", configContext.getProperty(TENANT_PRIVATE_KEY_ID).getValue()); 
-		}
+    @Override
+    public Authentication getAuthentication() {
+        Map<String, String> authParams = new HashMap<>();
 
- 		try {
-			return AuthenticationFactory.create(AuthenticationAthenz.class.getName(), authParams);
-		} catch (UnsupportedAuthenticationException e) {
-			getLogger().error("Unable to authenticate", e);
-			return null;
-		}
-	}
+        putAuthParamIfSet(authParams, "tenantDomain", configContext.getProperty(TENANT_DOMAIN));
+        putAuthParamIfSet(authParams, "tenantService", configContext.getProperty(TENANT_SERVICE));
+        putAuthParamIfSet(authParams, "providerDomain", configContext.getProperty(PROVIDER_DOMAIN));
+        putAuthParamIfSet(authParams, "privateKey", configContext.getProperty(TENANT_PRIVATE_KEY_FILE));
+        putAuthParamIfSet(authParams, "keyId", configContext.getProperty(TENANT_PRIVATE_KEY_ID));
+        putAuthParamIfSet(authParams, "autoPrefetchEnabled", configContext.getProperty(AUTO_PREFETCH_ENABLED));
+        putAuthParamIfSet(authParams, "athenzConfPath", configContext.getProperty(ATHENZ_CONF_PATH));
+        putAuthParamIfSet(authParams, "principalHeader", configContext.getProperty(PRINCIPAL_HEADER));
+        putAuthParamIfSet(authParams, "roleHeader", configContext.getProperty(ROLE_HEADER));
+        putAuthParamIfSet(authParams, "ztsUrl", configContext.getProperty(ZTS_URL));
+
+        try {
+            return AuthenticationFactory.create(AuthenticationAthenz.class.getName(), authParams);
+        } catch (UnsupportedAuthenticationException e) {
+            getLogger().error("Unable to authenticate", e);
+            return null;
+        }
+    }
+
+    private void putAuthParamIfSet(Map<String, String> authParams, String key, PropertyValue value) {
+        if (value.isSet()) {
+            authParams.put(key, value.getValue());
+        }
+    }
 
 }


### PR DESCRIPTION
There are more kind of auth params than can be given to the Pulsar's `AuthenticationAthenz` class as in [1]. The current properties of the PulsarClientAthenzAuthenticationService support some of them. This PR will add several properties to support all of them.

[1] https://github.com/apache/pulsar/blob/6ff1bbae0fe230eb72d62574d7685a745f884416/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java#L143-L156