### PR TITLE
Add description and tags to the PulsarClientAuthenticationServices

### DIFF
--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/StandardPulsarClientService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/StandardPulsarClientService.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.annotation.lifecycle.OnShutdown;
@@ -38,6 +40,10 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 
+@Tags({"Pulsar", "client", "pool"})
+@CapabilityDescription("Standard implementation of the PulsarClientService. "
+        + "Provides the ability to create Pulsar Producer / Consumer instances on demand, "
+        + "based on the configuration properties defined.")
 public class StandardPulsarClientService extends AbstractControllerService implements PulsarClientService {
 
     public static final PropertyDescriptor PULSAR_SERVICE_URL = new PropertyDescriptor.Builder()

--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientAthenzAuthenticationService.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.pulsar.client.api.Authentication;
@@ -34,6 +36,10 @@ import org.apache.pulsar.client.impl.auth.AuthenticationAthenz;
  * https://pulsar.apache.org/docs/en/security-athenz/
  *
  */
+@Tags({"Pulsar", "client", "security", "authentication", "Athenz"})
+@CapabilityDescription("Implementation with Athenz Authentication of the PulsarClientAuthenticationService. "
+        + "Provides Pulsar clients with the ability to authenticate against a "
+        + "secured Apache Pulsar broker endpoint.")
 public class PulsarClientAthenzAuthenticationService extends AbstractPulsarClientAuntenticationService {
 	
     public static final PropertyDescriptor TENANT_DOMAIN = new PropertyDescriptor.Builder()

--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientJwtAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientJwtAuthenticationService.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.pulsar.client.api.Authentication;
@@ -29,6 +31,10 @@ import org.apache.pulsar.client.api.AuthenticationFactory;
  * http://pulsar.apache.org/docs/en/security-token-client/
  *
  */
+@Tags({"Pulsar", "client", "security", "authentication", "JWT"})
+@CapabilityDescription("Implementation with JSON Web Token (JWT) Authentication of the PulsarClientAuthenticationService. "
+        + "Provides Pulsar clients with the ability to authenticate against a "
+        + "secured Apache Pulsar broker endpoint.")
 public class PulsarClientJwtAuthenticationService extends AbstractPulsarClientAuntenticationService {
 
     public static final PropertyDescriptor JWT_TOKEN = new PropertyDescriptor.Builder()

--- a/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientTlsAuthenticationService.java
+++ b/nifi-pulsar-client-service/src/main/java/org/apache/nifi/pulsar/auth/PulsarClientTlsAuthenticationService.java
@@ -22,12 +22,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 
+@Tags({"Pulsar", "client", "security", "authentication", "TLS"})
+@CapabilityDescription("Implementation with TLS Authentication of the PulsarClientAuthenticationService. "
+        + "Provides Pulsar clients with the ability to authenticate against a "
+        + "secured Apache Pulsar broker endpoint.")
 public class PulsarClientTlsAuthenticationService extends AbstractPulsarClientAuntenticationService {
 
     public static final PropertyDescriptor CLIENT_CERTIFICATE = new PropertyDescriptor.Builder()


### PR DESCRIPTION
There are no description or tags for the all of four controller services. This PR will add them.