### PR TITLE
Use cumulative acks not only on Exclusive but also on Failover subscriptions

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -58,8 +58,8 @@ import org.apache.pulsar.client.api.SubscriptionType;
 public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcessor {
 
     protected static final AllowableValue EXCLUSIVE = new AllowableValue("Exclusive", "Exclusive", "There can be only 1 consumer on the same topic with the same subscription name");
-    static final AllowableValue SHARED = new AllowableValue("Shared", "Shared", "Multiple consumer will be able to use the same subscription name and the messages");
-    static final AllowableValue FAILOVER = new AllowableValue("Failover", "Failover", "Multiple consumer will be able to use the same subscription name but only 1 consumer "
+    protected static final AllowableValue SHARED = new AllowableValue("Shared", "Shared", "Multiple consumer will be able to use the same subscription name and the messages");
+    protected static final AllowableValue FAILOVER = new AllowableValue("Failover", "Failover", "Multiple consumer will be able to use the same subscription name but only 1 consumer "
             + "will receive the messages. If that consumer disconnects, one of the other connected consumers will start receiving messages.");
 
     static final AllowableValue CONSUME = new AllowableValue(ConsumerCryptoFailureAction.CONSUME.name(), "Consume",


### PR DESCRIPTION
In the current implementation of consumers, cumulative acks are only performed on Exclusive subscriptions. However, cumulative acks are also permitted on Failover subscriptions type, in other word, cumulative acks are not permitted only on Shared subscriptions. Cumulative acks are believed to be better, so why don't we use cumulative acks not only on Exclusive but also on Failover subscriptions?

**Reference:** Consumer (Pulsar Client Java API) https://pulsar.apache.org/api/client/org/apache/pulsar/client/api/Consumer.html#acknowledgeCumulative-org.apache.pulsar.client.api.Message-
> Cumulative acknowledge cannot be used when the consumer type is set to ConsumerShared.