### PR TITLE
Close FlowFile before removing it to avoid the IllegalStateException

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -226,8 +226,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<byte[]>
           parseFailures.addAll(messages);
 
           // We aren't going to write any records to the FlowFile, so remove it and close the associated output stream
-          session.remove(flowFile);
           IOUtils.closeQuietly(rawOut);
+          session.remove(flowFile);
           getLogger().error("Unable create a record writer to consume from the Pulsar topic");
        } else {
            try {


### PR DESCRIPTION
If we are unable to determine the schema, the following IllegalStateException occurs. The reason I see is that it tries to remove the FlowFile before closing the output stream. This PR fixes it.

```
2019-09-11 12:35:48,283 ERROR [Timer-Driven Process Thread-9] o.a.n.p.p.pubsub.ConsumePulsarRecord ConsumePulsarRecord[id=0403e252-9e73-3a30-9835-4db322741adc] ConsumePulsarRecord[id=0403e252-9e73-3a30-9835-4db322741adc] failed to process session due to java.lang.IllegalStateException: StandardFlowFileRecord[uuid=c14f981c-17de-4cff-9983-950c0316954b,claim=,offset=0,name=c14f981c-17de-4cff-9983-950c0316954b,size=0] already in use for an active callback or an OutputStream created by ProcessSession.write(FlowFile) has not been closed; Processor Administratively Yielded for 1 sec: java.lang.IllegalStateException: StandardFlowFileRecord[uuid=c14f981c-17de-4cff-9983-950c0316954b,claim=,offset=0,name=c14f981c-17de-4cff-9983-950c0316954b,size=0] already in use for an active callback or an OutputStream created by ProcessSession.write(FlowFile) has not been closed
java.lang.IllegalStateException: StandardFlowFileRecord[uuid=c14f981c-17de-4cff-9983-950c0316954b,claim=,offset=0,name=c14f981c-17de-4cff-9983-950c0316954b,size=0] already in use for an active callback or an OutputStream created by ProcessSession.write(FlowFile) has not been closed
	at org.apache.nifi.controller.repository.StandardProcessSession.validateRecordState(StandardProcessSession.java:3129)
	at org.apache.nifi.controller.repository.StandardProcessSession.validateRecordState(StandardProcessSession.java:3121)
	at org.apache.nifi.controller.repository.StandardProcessSession.remove(StandardProcessSession.java:1979)
	at org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord.consumeMessages(ConsumePulsarRecord.java:229)
	at org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord.onTrigger(ConsumePulsarRecord.java:170)
	at org.apache.nifi.processor.AbstractProcessor.onTrigger(AbstractProcessor.java:27)
	at org.apache.nifi.controller.StandardProcessorNode.onTrigger(StandardProcessorNode.java:1162)
	at org.apache.nifi.controller.tasks.ConnectableTask.invoke(ConnectableTask.java:209)
	at org.apache.nifi.controller.scheduling.TimerDrivenSchedulingAgent$1.run(TimerDrivenSchedulingAgent.java:117)
	at org.apache.nifi.engine.FlowEngine$2.run(FlowEngine.java:110)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```