### PR TITLE
Update to acknowledge messages only if all NiFi processes succeed, and fix to use proper ack APIs depending on the setting

### DIFF
--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -120,8 +120,12 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
         assertEquals(iterations, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), times(iterations * (batchSize+1))).receive(0, TimeUnit.SECONDS);
-        verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(iterations * (batchSize + 1))).receive(0, TimeUnit.SECONDS);
+        if (async) {
+            verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledgeAsync(mockMessage);
+        } else {
+            verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledge(mockMessage);
+        }
 
         return flowFiles;
     }


### PR DESCRIPTION
To avoid losing consumed messages, we should not send acknowledgements when a flowfile process (e.g., writing of flowfile/record) fails, we should do only if the flowfile process succeeds.

Also, acknowledgement APIs can be distinguished depending on the subscription type and the async mode as shown in the table. This PR also fixes it.

| | Subscription type: Shared | Not Shared |
|--|--|--|
| **Processor: Async disable** | `acknowledge` | `acknowledgeCumulative` |
| **Processor: Async enable** | `acknowledgeAsync` | `acknowledgeCumulativeAsync` |

Reference: Consumer (Pulsar Client Java API) https://pulsar.apache.org/api/client/org/apache/pulsar/client/api/Consumer.html